### PR TITLE
move from id to cv_email

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var Woopra = module.exports = integration('Woopra')
   // is just unnecessary overhead/error prone for customers.
   .endpoint('http://www.woopra.com/track')
   .ensure('settings.domain')
+  .ensure('message.email')
   .channels(['server'])
   .mapper(mapper)
   .retries(2);

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -18,7 +18,6 @@ exports.identify = function(identify){
   var traits = prefixKeys(identify.traits(), 'cv_');
   delete traits.cv_id;
   return extend(traits, {
-    id: identify.userId(),
     cv_company: identify.proxy('traits.company'),
     timestamp: identify.timestamp().getTime(),
     timeout: timeout(identify, this.settings),
@@ -41,9 +40,10 @@ exports.identify = function(identify){
 
 exports.track = function(track){
   var props = prefixKeys(track.properties(), 'ce_');
+  props.cv_email = props.ce_email;
   delete props.ce_id;
+  delete props.ce_email;
   return extend(props, {
-    id: track.userId(),
     timestamp: track.timestamp().getTime(),
     timeout: timeout(track, this.settings),
     ce_name: track.event(),

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -4,7 +4,8 @@
     "userId": "user-id",
     "timestamp": "2014",
     "traits": {
-      "name": "john doe"
+      "name": "john doe",
+      "email":"name@example.com"
     },
     "context": {
       "ip": "0.0.0.0",
@@ -13,8 +14,8 @@
   },
   "output": {
     "cookie": "e35c1a36e525c2e4642c43b55246de30",
-    "id": "user-id",
     "cv_name": "john doe",
+    "cv_email":"name@example.com",
     "host": "ivolo.me",
     "ip": "0.0.0.0",
     "timeout": 30,

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -6,14 +6,15 @@
     "timestamp": "2014",
     "properties": {
       "revenue": 19.99,
-      "property": true
+      "property": true,
+      "email":"name@example.com"
     }
   },
   "output": {
-    "id": "user-id",
     "ce_name": "my-event",
     "ce_property": true,
     "ce_revenue": 19.99,
+    "cv_email": "name@example.com",
     "host": "ivolo.me",
     "cookie": "e35c1a36e525c2e4642c43b55246de30",
     "timeout": 30,

--- a/test/index.js
+++ b/test/index.js
@@ -22,17 +22,29 @@ describe('Woopra', function(){
       .name('Woopra')
       .endpoint('http://www.woopra.com/track')
       .ensure('settings.domain')
+      .ensure('message.email')
       .channels(['server']);
   });
 
   describe('.validate()', function(){
+    var msg;
+
+    beforeEach(function(){
+      msg = {
+        type: 'identify',
+        traits: {
+          email: 'jd@example.com'
+        }
+      };
+    });
+
     it('should be invalid if .domain is missing', function(){
       delete settings.domain;
-      test.invalid({}, settings);
+      test.invalid(msg, settings);
     });
 
     it('should be valid if settings are complete', function(){
-      test.valid({}, settings);
+      test.valid(msg, settings);
     });
   });
 
@@ -53,7 +65,7 @@ describe('Woopra', function(){
   describe('.track()', function(){
     it('should track successfully', function(done){
       var track = {
-        properties: { revenue: 100, prop: 'prop' },
+        properties: { revenue: 100, prop: 'prop', email: 'name@example.com' },
         context: { ip: '127.0.0.1' },
         timestamp: new Date(),
         userId: 'userId',
@@ -64,10 +76,10 @@ describe('Woopra', function(){
         .set(settings)
         .track(track)
         .query({
-          id: track.userId,
           timestamp: track.timestamp.getTime().toString(),
           cookie: md5('userId'),
           host: settings.domain,
+          cv_email: 'name@example.com',
           ce_name: 'event',
           ce_revenue: '100',
           ce_prop: 'prop',
@@ -81,17 +93,17 @@ describe('Woopra', function(){
   describe('.identify()', function(){
     it('should identify successfully', function(done){
       var identify = {
-        traits: { company: 'company', name: 'name' },
+        traits: { company: 'company', name: 'name', email: 'name@example.com' },
         context: { ip: '127.0.0.1' },
         timestamp: new Date(),
-        userId: 'userId',
+        userId: 'userId'
       };
 
       test
         .set(settings)
         .identify(identify)
         .query({
-          id: identify.userId,
+          cv_email: 'name@example.com',
           timestamp: identify.timestamp.getTime().toString(),
           cookie: md5('userId'),
           host: settings.domain,


### PR DESCRIPTION
Woopra deprecated the `id` parameter in favor of `cv_email` as unique identifier so that they can easily tie all their apps in appconnect together: https://www.woopra.com/docs/developer/http-tracking-api/

This moves us to an approach akin to [drip](https://github.com/segmentio/integration-drip/blob/master/test/index.js#L34) where we have to ensure for email in every message — including `track`s :( — so that users can still send their true database id userId in the userId field and not have to send an email as userId.

**Very** open to further discussion here as to whether this is the right overall approach. Thoughts?

@amillet89 @f2prateek 