### PR TITLE
strip null cv_id

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -53,7 +53,7 @@ exports.track = function(track){
  */
 
 function createBasePayload(message, settings){
-  return reject({
+  return reject.types({
     cv_id: message.userId(),
     timestamp: message.timestamp().getTime().toString(),
     timeout: timeout(message, settings),
@@ -63,7 +63,7 @@ function createBasePayload(message, settings){
     ua: message.userAgent(),
     context: JSON.stringify(message.options()),
     ip: message.ip()
-  });
+  }, ['null', 'undefined']);
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -100,8 +100,8 @@ describe('Woopra', function(){
       var json = test.fixture('identify-basic');
 
       // we delete these prior to the request after the mapper
-      delete json.output.ua
-      delete json.output.lang
+      delete json.output.ua;
+      delete json.output.lang;
 
       test
         .set(settings)
@@ -113,15 +113,30 @@ describe('Woopra', function(){
     it('should override cookie if provided', function(done){
       var json = test.fixture('identify-cookie');
 
-      delete json.output.ua
-      delete json.output.lang
+      delete json.output.ua;
+      delete json.output.lang;
       
       test
         .set(settings)
         .identify(json.input)
         .query(json.output)
         .expects(200, done);
-    })
+    });
+
+    it('should strip cv_id if undefined/null', function(done){
+      var json = test.fixture('identify-cookie');
+
+      delete json.output.ua;
+      delete json.output.lang;
+      json.input.userId = null;
+      delete json.output.cv_id;
+
+      test
+        .set(settings)
+        .identify(json.input)
+        .query(json.output)
+        .expects(200, done);
+    });
   });
 });
 


### PR DESCRIPTION
from request by Woopra folks -- we should reject cv_id if `userId` is null.

Adding tests to confirm this behavior.