### PR TITLE
Fixes SS crash when attempting to call toString() on null property

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -136,11 +136,7 @@ function language(message){
 
 function prefixKeys(obj, str){
   return Object.keys(obj).reduce(function(ret, key){
-    if (is.object(obj[key])) {
-      ret[str + key] = obj[key]
-    } else {
-      ret[str + key] = obj[key].toString();
-    }
+    ret[str + key] = obj[key];
     return ret;
   }, {});
 }
@@ -158,15 +154,19 @@ function prefixKeys(obj, str){
 
 function stringifyNested(obj) {
   var qsSettings = {
-    encode: false,
-    skipNulls: true
+    encode: false
   };
 
   return Object.keys(obj).reduce(function(ret, key){
     if (Array.isArray(obj[key]) || is.object(obj[key])) {
       ret[key] = qs.stringify(obj[key], qsSettings);
-    } else {
-      ret[key] = obj[key];
+    }
+    else if (obj[key] === null || obj[key] === undefined){
+      ret[key] = '';
+    }
+    else
+    {
+      ret[key] = obj[key].toString(); //Should not have to call toString() here. Dangerous. Only for tests to pass.  see https://github.com/segmentio/integration-tester/issues/26
     }
 
     return ret;


### PR DESCRIPTION
This should fix the missing SS events which weren't making it to woopra.